### PR TITLE
change faucet.js to initiate contracts using addresses from coordinator

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -81,3 +81,9 @@ export default config;
 
 
 
+
+
+
+
+
+

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -131,6 +131,7 @@ async function main() {
   await Coordinator.addImmutableContract('DATABASE', Database.address);               
   await Coordinator.addImmutableContract('ARBITER', Arbiter.address);
   await Coordinator.addImmutableContract('ZAP_TOKEN', zapToken.address);
+  await Coordinator.addImmutableContract('FAUCET', faucet.address);
   await Coordinator.updateContract('REGISTRY', Registry.address);
   await Coordinator.updateContract('CURRENT_COST', CurrentCost.address);
 

--- a/tasks/faucet.js
+++ b/tasks/faucet.js
@@ -13,13 +13,17 @@ task("faucet", "Sends 100K ZAP to the first 20 accounts")
         // Test accounts
         const signers = await ethers.getSigners();
 
+        // Connection to Coordinator
+        const Coordinator = await ethers.getContractFactory('ZapCoordinator')
+        const coordinator = await Coordinator.attach('0xe7f1725e7734ce288f8367e1bb143e90bb3f0512')
+
         // Connection to ZapToken.sol
         const Token = await ethers.getContractFactory('ZapToken')
-        const token = await Token.attach('0x5FbDB2315678afecb367f032d93F642f64180aa3');
+        const token = await Token.attach(await coordinator.getContract('ZAP_TOKEN'));
 
         // Connection to Faucet.sol
         const Faucet = await ethers.getContractFactory('Faucet');
-        const faucet = await Faucet.attach('0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512');
+        const faucet = await Faucet.attach(await coordinator.getContract('FAUCET'));
 
         // ZapToken.sol funds test ZAP to Faucet.sol
         await token.allocate(faucet.address, 1000000000)


### PR DESCRIPTION
# Summary

Fixes error which came about after adding MPO.

# Implementation

Originally, the Faucet was attached using the wrong address. Change it so that ZapToken and Faucet is started using the address requested from the Coordinator. Had to add the Faucet to the Coordinator in the deploy script.

# Files
```
task/faucet.js
scripts/deploy.ts
```

# Preview
![Screen Shot 2021-01-18 at 11 52 59 PM](https://user-images.githubusercontent.com/24558257/104989443-74b16680-59e8-11eb-8dd3-deb38e5b1a45.png)
![Screen Shot 2021-01-18 at 11 53 23 PM](https://user-images.githubusercontent.com/24558257/104989446-7713c080-59e8-11eb-8db6-dec9368badb2.png)
