### PR TITLE
Update from feature/registry-test

### DIFF
--- a/test/RegistryTest.ts
+++ b/test/RegistryTest.ts
@@ -61,8 +61,11 @@ describe('Registry Test', () => {
         await registry.deployed();
 
         await database.transferOwnership(coordinator.address);
+
         await coordinator.addImmutableContract('DATABASE', database.address);
+
         await coordinator.updateContract('REGISTRY', registry.address);
+        
         await coordinator.updateAllDependencies();
 
     });

--- a/test/RegistryTest.ts
+++ b/test/RegistryTest.ts
@@ -52,7 +52,7 @@ describe('Registry Test', () => {
         registryFactory = await ethers.getContractFactory('Registry', signers[0]);
 
         database = (await databaseFactory.deploy()) as Database;
-        await database.deploye();
+        await database.deploy();
 
         coordinator = (await coordinatorFactory.deploy()) as ZapCoordinator;
         await coordinator.deployed();

--- a/test/RegistryTest.ts
+++ b/test/RegistryTest.ts
@@ -16,6 +16,20 @@ const { expect } = chai;
 
 describe('Registry Test', () => {
 
+    /**
+     * @param database Stores the deployed Database
+     * @param coordinator Stores the deployed Coordinator
+     * @param registry Stores the deployed Registry
+     * @param databaseFactory Stores the instance of the Database
+     * @param coordinatorFactory Stores the instance of the Coordinator
+     * @param registryFactory Stores the instance of the Registry
+     * @param signers Contains the 20 test accounts provider by Hardhat
+     * @param providerTitle Stores the testProvider.title converted as a bytes32 string
+     * @param convertedEndpoint Stores the testProvider.endpoint converted as a bytes32 string
+     * @param convertedParams Stores the test markdown and JSON params inside an array
+     * @param parameters Stores the test markdown and JSON URL's inside an array
+     */
+
     let database: Database;
     let coordinator: ZapCoordinator;
     let registry: Registry;
@@ -23,10 +37,22 @@ describe('Registry Test', () => {
     let coordinatorFactory: any;
     let registryFactory: any;
     let signers: any;
-    let providerTitle: any;
-    let convertedEndpoint: any;
-    let convertedParams: any;
-    let parameters: any;
+    let providerTitle: string;
+    let convertedEndpoint: string;
+    let convertedParams: string[];
+    let parameters: string[];
+
+    /**
+     * @param testProvider Stores the key/value pairs needed to create, read, and maintain a provider
+     * @param publicKey Stores the test unique id to instantiate a provider
+     * @param title Name of the test provider before bytes32 conversion
+     * @param endpointParams Stores the test endpoint params before bytes32 conversion
+     * @param markdownFile Stores the test curve markdown file before bytes32 conversion
+     * @param jsonFile Stores the test curve JSON file before bytes32 conversion
+     * @param endpoint Stores the test endpoint before bytes32 conversion
+     * @param curve Stores the test coefficient array for the provider curve
+     * @param emptyBroker Stores the test 0x0 broker address
+     */
 
     const testProvider = {
 
@@ -43,47 +69,54 @@ describe('Registry Test', () => {
 
     beforeEach(async () => {
 
+        // Gets the 20 test accounts
         signers = await ethers.getSigners();
 
+        // First signer instantiating the Coordinator, Database, and Registry contracts
         coordinatorFactory = await ethers.getContractFactory('ZapCoordinator', signers[0]);
-
         databaseFactory = await ethers.getContractFactory('Database', signers[0]);
-
         registryFactory = await ethers.getContractFactory('Registry', signers[0]);
 
+        // Deploys the Database contract
         database = (await databaseFactory.deploy()) as Database;
         await database.deployed();
 
+        // Deployes the Coordinator contract
         coordinator = (await coordinatorFactory.deploy()) as ZapCoordinator;
         await coordinator.deployed();
 
+        // Deploys the Registry Contract
         registry = (await registryFactory.deploy(coordinator.address)) as Registry;
         await registry.deployed();
+
 
         await database.transferOwnership(coordinator.address);
 
         await coordinator.addImmutableContract('DATABASE', database.address);
 
         await coordinator.updateContract('REGISTRY', registry.address);
-        
+
         await coordinator.updateAllDependencies();
 
     });
 
     it('REGISTRY_1 - Should be able to create an instance of the ZapCoordinator contract', () => {
 
+        // Expects coordinatorFactory to be fulfilled
         expect(coordinatorFactory).to.be.ok;
 
     });
 
     it('REGISTRY_2 - Should be able to create an instance of the Registry contract', () => {
 
+        // Expects registryFactory to be fulfilled
         expect(registryFactory).to.be.ok;
 
     });
 
     it('REGISTRY_3 - Should be able to create an instance of the Database contract', () => {
 
+        // Expects databaseFactory to be fulfilled
         expect(databaseFactory).to.be.ok;
 
     });
@@ -91,26 +124,31 @@ describe('Registry Test', () => {
 
     it('REGISTRY_4 - Should be able to deploy the ZapCoordinator contract', () => {
 
+        // Expects coordinator to be fulfilled
         expect(coordinator).to.be.ok;
 
     });
 
     it('REGISTRY_5 - Should be able to deploy the Registry contract', () => {
 
+        // Expects registry to be fulfilled
         expect(registry).to.be.ok;
 
     });
 
     it('REGISTRY_6 - Should be able to deploy the Database contract', () => {
 
+        // Expects database to be fulfilled
         expect(database).to.be.ok;
 
     });
 
     it("REGISTRY_7 - initiateProvider() - Check that we can initiate provider", async () => {
 
+        // Converts testProvider.title to a bytes32 string
         providerTitle = ethers.utils.formatBytes32String(testProvider.title);
 
+        // Expect the initiateProvider function to be fulfilled
         expect(await registry.initiateProvider(testProvider.publicKey, providerTitle,)).to.be.ok;
 
     });
@@ -118,15 +156,21 @@ describe('Registry Test', () => {
     it("REGISTRY_8 - initiateProvider() - Check that we can't change provider info if it was initated",
         async () => {
 
+            // New provider title used to test against the provider already initiated
             const newTestTitle = ethers.utils.formatBytes32String('newTestProvider');
+
+            // New public key used to test against the provider already initiated
             const newPublicKey = 789;
 
+            // Converts testProvider.title to a bytes32 string
             providerTitle = ethers.utils.formatBytes32String(testProvider.title);
 
+            // Expect the initiateProvider to be fulfilled
             expect(await registry.initiateProvider(testProvider.publicKey, providerTitle,)).to.be.ok;
 
             try {
 
+                // Expect trying to initiate a provider twice to throw an error
                 expect(await registry.initiateProvider(newPublicKey, newTestTitle)).to.throw(
 
                     'Provider is already initiated'
@@ -142,11 +186,16 @@ describe('Registry Test', () => {
     it("REGISTRY_9 - initiateProviderCurve() - Check that we can initiate provider curve",
         async () => {
 
+            // Converts testProvider.title to a bytes32 string
             providerTitle = ethers.utils.formatBytes32String(testProvider.title);
+
+            // Converts testProvider.endpoint to a bytes32 string
             convertedEndpoint = ethers.utils.formatBytes32String(testProvider.endpoint);
 
+            // Expect the intiateProvider to be fulfilled
             expect(await registry.initiateProvider(testProvider.publicKey, providerTitle,)).to.be.ok;
 
+            // Expect the initiateProviderCurve to be fulfilled
             expect(await registry.initiateProviderCurve(convertedEndpoint, testProvider.curve,
                 testProvider.emptyBroker
             )).to.be.ok;
@@ -156,10 +205,12 @@ describe('Registry Test', () => {
     it("REGISTRY_10 - initiateProviderCurve() - Check that we can't initiate provider curve if provider wasn't initiated",
         async () => {
 
+            // Converts testProvider.endpoint to a bytes32 string
             convertedEndpoint = ethers.utils.formatBytes32String(testProvider.endpoint);
 
             try {
 
+                // Expect trying to initiate a curve without initiating the provider to throw an error
                 expect(await registry.initiateProviderCurve(
                     convertedEndpoint,
                     testProvider.curve,
@@ -177,65 +228,93 @@ describe('Registry Test', () => {
     it("REGISTRY_11 - get/setEndpointParams() - Check that we can get and set provider endpoint parameters",
         async () => {
 
+            // Converts the testProvider.title to a bytes32 string
             providerTitle = ethers.utils.formatBytes32String(testProvider.title);
+
+            // Converts testProvider.endpoint to a bytes32 string
             convertedEndpoint = ethers.utils.formatBytes32String(testProvider.endpoint);
+
+            // Converts testProvider.endpointParams to an array of bytes32 strings
             convertedParams = testProvider.endpointParams.map(param => ethers.utils.formatBytes32String(param));
 
+            // Expect initiateProvider to be fulfilled
             expect(await registry.initiateProvider(
                 testProvider.publicKey,
                 providerTitle,
             )).to.be.ok;
 
+            // Expect initiateProviderCurve to be fulfilled
             expect(await registry.initiateProviderCurve(convertedEndpoint, testProvider.curve,
                 testProvider.emptyBroker
             )).to.be.ok;
 
-
+            // Expect setEndpointParams to be fulfilled
             expect(await registry.setEndpointParams(convertedEndpoint, convertedParams)).to.be.ok;
 
+            // Stores the endpoint params from the provider
             const getParams = await registry.getEndpointParams(signers[0].address, convertedEndpoint);
 
+            // Expect the first param(markdown param) returned to equal the first converted param
             expect(getParams[0]).to.equal(convertedParams[0]);
+
+            // Expect the second param(JSON param) returned to equal the second converted param
             expect(getParams[1]).to.equal(convertedParams[1]);
         });
 
     it("REGISTRY_12 - get/setProviderParameter() - Check that we can get and set provider parameters",
         async () => {
 
+            // Converts the provider title to a bytes32 string
             providerTitle = ethers.utils.formatBytes32String(testProvider.title);
+
+            // Converts testProvider.endpointParams to an array of bytes32 strings
             convertedParams = testProvider.endpointParams.map(param => ethers.utils.formatBytes32String(param));
+
+            // Converts testProvider.endpoint to a bytes32 string
             convertedEndpoint = ethers.utils.formatBytes32String(testProvider.endpoint);
+
+            // Stores the markdown & JSON URL's in an array
             parameters = [testProvider.markdownFile, testProvider.jsonFile];
+
+            // Will store the converted parameters
             let bytesParameters = [];
 
             for (var i = 0; i < parameters.length; i++) {
 
+                // Storing each converted parameter
                 bytesParameters.push(ethers.utils.toUtf8Bytes(parameters[i]));
             }
 
+            // Convert to bytes
             bytesParameters = bytesParameters.map(parameter => ethers.utils.hexlify(parameter));
 
+            // Expect initiateProvider to be fulfilled
             expect(await registry.initiateProvider(testProvider.publicKey, providerTitle,
             )).to.be.ok;
 
+            // Expect initiateProviderCurve to be fulfilled
             expect(await registry.initiateProviderCurve(convertedEndpoint, testProvider.curve,
                 testProvider.emptyBroker
             )).to.be.ok;
 
+            // Expect setEndpointParams to be fulfilled
             expect(await registry.setEndpointParams(convertedEndpoint, convertedParams
             )).to.be.ok;
 
+            // Stores the endpoint params from the provider
             const getParams = await registry.getEndpointParams(signers[0].address, convertedEndpoint);
 
-            expect(await registry.setProviderParameter(
-                getParams[0],
-                bytesParameters[0])).to.be.ok;
+            // Expect the setProviderParameter on the markdown link to be fulfilled
+            expect(await registry.setProviderParameter(getParams[0], bytesParameters[0])).to.be.ok;
 
+            // Expect the setProviderParameter on the JSON link to be fulfilled
             expect(await registry.setProviderParameter(getParams[1], bytesParameters[1])).to.be.ok;
 
+            // Expect getProviderParameter on the markdown link to be fulfilled
             expect(await registry.getProviderParameter(signers[0].address, getParams[0]))
                 .to.equal(bytesParameters[0]);
 
+            // Expect the getProviderParameter on the JSON link to be fulfilled
             expect(await registry.getProviderParameter(signers[0].address, getParams[1]))
                 .to.equal(bytesParameters[1]);
 
@@ -243,27 +322,35 @@ describe('Registry Test', () => {
 
     it("REGISTRY_13 - getProviderTitle() - Check that we can get provider title", async () => {
 
+        // Converts testProvider.title to a bytes32 string
         providerTitle = ethers.utils.formatBytes32String(testProvider.title);
 
+        // Expects initiateProvider to be fulfilled
         expect(await registry.initiateProvider(testProvider.publicKey, providerTitle,
         )).to.be.ok;
 
+        // Expects getProviderTitle to be fulfilled
         expect(await registry.getProviderTitle(signers[0].address)).to.equal(providerTitle);
 
     });
 
+
     it("REGISTRY_14 - getProviderTitle() - Check that title of uninitialized provider is empty", async () => {
 
+        // Expect getProviderTitle to be fulfilled
         expect(await registry.getProviderTitle(signers[0].address))
             .to.equal('0x0000000000000000000000000000000000000000000000000000000000000000');
     });
 
     it("REGISTRY_15 - getProviderPublicKey() - Check that we can get provider public key", async () => {
 
+        // Converts testProvider.title to a bytes32 string
         providerTitle = ethers.utils.formatBytes32String(testProvider.title);
 
+        // Expect initiateProvider to be fulfilled
         expect(await registry.initiateProvider(testProvider.publicKey, providerTitle,)).to.be.ok;
 
+        // Expect getProviderPublicKey to be returned
         expect(await registry.getProviderPublicKey(signers[0].address)).to.equal(testProvider.publicKey);
 
     });
@@ -271,49 +358,73 @@ describe('Registry Test', () => {
     it("REGISTRY_16 - getProviderPublicKey() - Check that public key of uninitialized provider is equal to 0",
         async () => {
 
+            // Expects to fulfill without being initialized
             expect(await registry.getProviderPublicKey(signers[0].address)).to.equal(0);
 
         });
 
     it("REGISTRY_17 - getProviderCurve() - Check that we initialize and get provider curve", async () => {
 
+        // Converts testProvider.title to a bytes32 string
         providerTitle = ethers.utils.formatBytes32String(testProvider.title);
+
+        // Converts testProvider.endpoint to a bytes32 string
         convertedEndpoint = ethers.utils.formatBytes32String(testProvider.endpoint);
 
+        // Expect intiateProvider to be fulfilled
         expect(await registry.initiateProvider(testProvider.publicKey, providerTitle,)).to.be.ok;
 
+        // Expect initiateProviderCurve to be fulfilled
         expect(await registry.initiateProviderCurve(convertedEndpoint, testProvider.curve, testProvider.emptyBroker
         )).to.be.ok;
 
+        // Will store the test endpoints curve
         const curve = [];
+
+        // Set curveLength to 0 for now
         let curveLength = 0;
+
+        // Returns the curve from the providers test endpoint as a hexstring
         const getCurve = await registry.getProviderCurve(signers[0].address, convertedEndpoint);
+
+        // Returns the curve length from the providers test endpoint 
         const getCurveLength = await registry.getProviderCurveLength(signers[0].address, convertedEndpoint);
 
         for (var i = 0; i < getCurve.length; i++) {
 
+            // Converts each array element from a hexstring to a readable integer
             curve.push(parseInt(getCurve[i]._hex));
         }
 
+        // Parses getCurveLength to a readable integer and sets the value for curve length
         curveLength = parseInt(getCurveLength._hex);
 
+        // Expect the manual curve length to equal the manual test provider curve length
         expect(curve.length).to.equal(testProvider.curve.length);
-        expect(curveLength).to.equal(testProvider.curve.length);
-        expect(curve).to.eql(testProvider.curve);
 
+        // Expect the returned getProviderCurveLength to equal the manual test provider curve length
+        expect(curveLength).to.equal(testProvider.curve.length);
+
+        // Expect the curve to equal thte test provider curve
+        expect(curve).to.eql(testProvider.curve);
 
     });
 
     it("REGISTRY_18 - getProviderCurve() - Check that cant get uninitialized curve ", async () => {
 
+        // Converts the testProvider.title to a bytes32 string
         providerTitle = ethers.utils.formatBytes32String(testProvider.title);
+
+        // Converts testProvider.endpoint to a bytes32 string
         convertedEndpoint = ethers.utils.formatBytes32String(testProvider.endpoint);
 
+        // Expect intitiate Provider to be fulfilled
         expect(await registry.initiateProvider(testProvider.publicKey, providerTitle,
         )).to.be.ok;
 
         try {
 
+            // Expect trying to get a provider curve that wasnt initialized to throw an error
             expect(await registry.getProviderCurve(signers[0].address, convertedEndpoint
             )).to.throw('Curve is not initialized')
 
@@ -326,59 +437,82 @@ describe('Registry Test', () => {
 
     it("REGISTRY_19 - getAllOracles() - Check that we can get all providers", async function () {
 
+        // Converts the testProvider.title to a bytes32 string
         providerTitle = ethers.utils.formatBytes32String(testProvider.title);
 
+        // Expect intiateProvider to be fulfilled
         expect(await registry.initiateProvider(testProvider.publicKey, providerTitle,)).to.be.ok;
 
+        // Stores the initiated providers returned
         const providers = await registry.getAllOracles();
 
+        // Expect the returned provider to be the same
         expect(providers[0]).to.equal(signers[0].address);
 
     });
 
     it("REGISTRY_20 - getEndpointBroker() - Check that broker address can be saved and retreived", async () => {
 
+        // Converts the testProvider.title to a bytes32 string
         providerTitle = ethers.utils.formatBytes32String(testProvider.title);
+
+        // Converts the testProvider.endpoint to a bytes32 string
         convertedEndpoint = ethers.utils.formatBytes32String(testProvider.endpoint);
 
+        // Expects the initiateProvider to be fulfilled
         expect(await registry.initiateProvider(testProvider.publicKey, providerTitle)).to.be.ok;
 
+        // Expects the initiateProviderCurve to be fulfilled
         expect(await registry.initiateProviderCurve(convertedEndpoint, testProvider.curve,
             testProvider.emptyBroker)).to.be.ok;
 
+        // Stores the broker address returned
         const brokerAddress = await registry.getEndpointBroker(signers[0].address, convertedEndpoint);
 
+        // Expects getEndpointBroker to equal testProvider.emptyBroker
         expect(brokerAddress).to.equal(testProvider.emptyBroker);
     });
 
     it("REGISTRY_21 - clearEndpoint() - Check that provider can clear endpoint with no bonds", async () => {
 
+        // Converts testProvider.title to a bytes32 string
         providerTitle = ethers.utils.formatBytes32String(testProvider.title);
+
+        // Converts testProvider.endpoint to a bytes32 string
         convertedEndpoint = ethers.utils.formatBytes32String(testProvider.endpoint);
 
+        // Expect initiateProvider to be fulfilled
         expect(await registry.initiateProvider(testProvider.publicKey, providerTitle)).to.be.ok;
 
+        // Expect initiateProviderCurve to be fulfilled
         expect(await registry.initiateProviderCurve(convertedEndpoint, testProvider.curve, testProvider.emptyBroker
         )).to.be.ok;
 
+        // Returns the endpoints of the provider
         const endpoint = await registry.getProviderEndpoints(signers[0].address);
 
+        // Expect clearEndpoint to be fulfilled
         expect(await registry.clearEndpoint(endpoint[0])).to.be.ok;
 
         const clearEndpoint = await registry.getProviderEndpoints(signers[0].address);
 
+        // Expect the cleared endpoint to be 0x0
         expect(clearEndpoint[0]).to.eql('0x0000000000000000000000000000000000000000000000000000000000000000');
 
     });
 
     it("REGISTRY_22 - setProviderTitle() - Check that provider can change their title", async () => {
 
+        // New provider title 
         const newProviderTitle = ethers.utils.formatBytes32String('newTestProvider');
 
+        // Expects initiateProvider to be fulfilled
         expect(await registry.initiateProvider(testProvider.publicKey, newProviderTitle)).to.be.ok;
 
+        // Expects setProviderTitle to be fulfilled
         expect(await registry.setProviderTitle(newProviderTitle)).to.be.ok;
 
+        // Expects the returned provider title be equal newProviderTitle
         expect(await registry.getProviderTitle(signers[0].address)).to.equal(newProviderTitle);
 
     });

--- a/test/RegistryTest.ts
+++ b/test/RegistryTest.ts
@@ -52,7 +52,7 @@ describe('Registry Test', () => {
         registryFactory = await ethers.getContractFactory('Registry', signers[0]);
 
         database = (await databaseFactory.deploy()) as Database;
-        await database.deploy();
+        await database.deployed();
 
         coordinator = (await coordinatorFactory.deploy()) as ZapCoordinator;
         await coordinator.deployed();
@@ -79,32 +79,32 @@ describe('Registry Test', () => {
 
     });
 
-    it('REGISTRY_2 - Should be able to create an instance of the Database contract', () => {
+    it('REGISTRY_3 - Should be able to create an instance of the Database contract', () => {
 
         expect(databaseFactory).to.be.ok;
 
     });
 
 
-    it('REGISTRY_3 - Should be able to deploy the ZapCoordinator contract', () => {
+    it('REGISTRY_4 - Should be able to deploy the ZapCoordinator contract', () => {
 
         expect(coordinator).to.be.ok;
 
     });
 
-    it('REGISTRY_4 - Should be able to deploy the Registry contract', () => {
+    it('REGISTRY_5 - Should be able to deploy the Registry contract', () => {
 
         expect(registry).to.be.ok;
 
     });
 
-    it('REGISTRY_4 - Should be able to deploy the Database contract', () => {
+    it('REGISTRY_6 - Should be able to deploy the Database contract', () => {
 
         expect(database).to.be.ok;
 
     });
 
-    it("REGISTRY_5 - initiateProvider() - Check that we can initiate provider", async () => {
+    it("REGISTRY_7 - initiateProvider() - Check that we can initiate provider", async () => {
 
         providerTitle = ethers.utils.formatBytes32String(testProvider.title);
 
@@ -112,7 +112,7 @@ describe('Registry Test', () => {
 
     });
 
-    it("REGISTRY_6 - initiateProvider() - Check that we can't change provider info if it was initated",
+    it("REGISTRY_8 - initiateProvider() - Check that we can't change provider info if it was initated",
         async () => {
 
             const newTestTitle = ethers.utils.formatBytes32String('newTestProvider');
@@ -136,7 +136,7 @@ describe('Registry Test', () => {
 
         });
 
-    it("REGISTRY_7 - initiateProviderCurve() - Check that we can initiate provider curve",
+    it("REGISTRY_9 - initiateProviderCurve() - Check that we can initiate provider curve",
         async () => {
 
             providerTitle = ethers.utils.formatBytes32String(testProvider.title);
@@ -150,7 +150,7 @@ describe('Registry Test', () => {
 
         });
 
-    it("REGISTRY_8 - initiateProviderCurve() - Check that we can't initiate provider curve if provider wasn't initiated",
+    it("REGISTRY_10 - initiateProviderCurve() - Check that we can't initiate provider curve if provider wasn't initiated",
         async () => {
 
             convertedEndpoint = ethers.utils.formatBytes32String(testProvider.endpoint);
@@ -171,7 +171,7 @@ describe('Registry Test', () => {
 
         });
 
-    it("REGISTRY_9 - get/setEndpointParams() - Check that we can get and set provider endpoint parameters",
+    it("REGISTRY_11 - get/setEndpointParams() - Check that we can get and set provider endpoint parameters",
         async () => {
 
             providerTitle = ethers.utils.formatBytes32String(testProvider.title);
@@ -196,7 +196,7 @@ describe('Registry Test', () => {
             expect(getParams[1]).to.equal(convertedParams[1]);
         });
 
-    it("REGISTRY_10 - get/setProviderParameter() - Check that we can get and set provider parameters",
+    it("REGISTRY_12 - get/setProviderParameter() - Check that we can get and set provider parameters",
         async () => {
 
             providerTitle = ethers.utils.formatBytes32String(testProvider.title);
@@ -238,7 +238,7 @@ describe('Registry Test', () => {
 
         });
 
-    it("REGISTRY_11 - getProviderTitle() - Check that we can get provider title", async () => {
+    it("REGISTRY_13 - getProviderTitle() - Check that we can get provider title", async () => {
 
         providerTitle = ethers.utils.formatBytes32String(testProvider.title);
 
@@ -249,13 +249,13 @@ describe('Registry Test', () => {
 
     });
 
-    it("REGISTRY_12 - getProviderTitle() - Check that title of uninitialized provider is empty", async () => {
+    it("REGISTRY_14 - getProviderTitle() - Check that title of uninitialized provider is empty", async () => {
 
         expect(await registry.getProviderTitle(signers[0].address))
             .to.equal('0x0000000000000000000000000000000000000000000000000000000000000000');
     });
 
-    it("REGISTRY_13 - getProviderPublicKey() - Check that we can get provider public key", async () => {
+    it("REGISTRY_15 - getProviderPublicKey() - Check that we can get provider public key", async () => {
 
         providerTitle = ethers.utils.formatBytes32String(testProvider.title);
 
@@ -265,14 +265,14 @@ describe('Registry Test', () => {
 
     });
 
-    it("REGISTRY_14 - getProviderPublicKey() - Check that public key of uninitialized provider is equal to 0",
+    it("REGISTRY_16 - getProviderPublicKey() - Check that public key of uninitialized provider is equal to 0",
         async () => {
 
             expect(await registry.getProviderPublicKey(signers[0].address)).to.equal(0);
 
         });
 
-    it("REGISTRY_15 - getProviderCurve() - Check that we initialize and get provider curve", async () => {
+    it("REGISTRY_17 - getProviderCurve() - Check that we initialize and get provider curve", async () => {
 
         providerTitle = ethers.utils.formatBytes32String(testProvider.title);
         convertedEndpoint = ethers.utils.formatBytes32String(testProvider.endpoint);
@@ -301,7 +301,7 @@ describe('Registry Test', () => {
 
     });
 
-    it("REGISTRY_16 - getProviderCurve() - Check that cant get uninitialized curve ", async () => {
+    it("REGISTRY_18 - getProviderCurve() - Check that cant get uninitialized curve ", async () => {
 
         providerTitle = ethers.utils.formatBytes32String(testProvider.title);
         convertedEndpoint = ethers.utils.formatBytes32String(testProvider.endpoint);
@@ -321,7 +321,7 @@ describe('Registry Test', () => {
 
     });
 
-    it("REGISTRY_17 - getAllOracles() - Check that we can get all providers", async function () {
+    it("REGISTRY_19 - getAllOracles() - Check that we can get all providers", async function () {
 
         providerTitle = ethers.utils.formatBytes32String(testProvider.title);
 
@@ -333,7 +333,7 @@ describe('Registry Test', () => {
 
     });
 
-    it("REGISTRY_18 - getEndpointBroker() - Check that broker address can be saved and retreived", async () => {
+    it("REGISTRY_20 - getEndpointBroker() - Check that broker address can be saved and retreived", async () => {
 
         providerTitle = ethers.utils.formatBytes32String(testProvider.title);
         convertedEndpoint = ethers.utils.formatBytes32String(testProvider.endpoint);
@@ -348,7 +348,7 @@ describe('Registry Test', () => {
         expect(brokerAddress).to.equal(testProvider.emptyBroker);
     });
 
-    it("REGISTRY_19 - clearEndpoint() - Check that provider can clear endpoint with no bonds", async () => {
+    it("REGISTRY_21 - clearEndpoint() - Check that provider can clear endpoint with no bonds", async () => {
 
         providerTitle = ethers.utils.formatBytes32String(testProvider.title);
         convertedEndpoint = ethers.utils.formatBytes32String(testProvider.endpoint);
@@ -368,7 +368,7 @@ describe('Registry Test', () => {
 
     });
 
-    it("REGISTRY_20 - setProviderTitle() - Check that provider can change their title", async () => {
+    it("REGISTRY_22 - setProviderTitle() - Check that provider can change their title", async () => {
 
         const newProviderTitle = ethers.utils.formatBytes32String('newTestProvider');
 

--- a/test/RegistryTest.ts
+++ b/test/RegistryTest.ts
@@ -52,11 +52,13 @@ describe('Registry Test', () => {
         registryFactory = await ethers.getContractFactory('Registry', signers[0]);
 
         database = (await databaseFactory.deploy()) as Database;
+        await database.deploye();
 
         coordinator = (await coordinatorFactory.deploy()) as ZapCoordinator;
         await coordinator.deployed();
 
         registry = (await registryFactory.deploy(coordinator.address)) as Registry;
+        await registry.deployed();
 
         await database.transferOwnership(coordinator.address);
         await coordinator.addImmutableContract('DATABASE', database.address);
@@ -77,6 +79,13 @@ describe('Registry Test', () => {
 
     });
 
+    it('REGISTRY_2 - Should be able to create an instance of the Database contract', () => {
+
+        expect(databaseFactory).to.be.ok;
+
+    });
+
+
     it('REGISTRY_3 - Should be able to deploy the ZapCoordinator contract', () => {
 
         expect(coordinator).to.be.ok;
@@ -86,6 +95,12 @@ describe('Registry Test', () => {
     it('REGISTRY_4 - Should be able to deploy the Registry contract', () => {
 
         expect(registry).to.be.ok;
+
+    });
+
+    it('REGISTRY_4 - Should be able to deploy the Database contract', () => {
+
+        expect(database).to.be.ok;
 
     });
 


### PR DESCRIPTION
## Summary
Registry tests passing for the functions needed to create, maintain and read provider data.

Closes #7 

## Implementation

- Test that ZapCoordinator can be deployed
- Test that the Database can be deployed
- Test that Registry can be deployed
- Test initiateProvider
- Test initiateProviderCurve
- Test setEndpointParams
- Test getEndpointParams
- Test setProviderParameters
- Test getProviderParameters
- Test getProviderTitle
- Test getProviderPublicKey
- Test getProviderCurve
- Test getAllOracles
- Test getEndpointBroker
- Test clearEndpoint
- Test setProviderTitle


## Files
``` test\RegistryTest.ts```

## Visual Preview
![Screenshot (149)](https://user-images.githubusercontent.com/42893948/105722991-448c2b00-5ef4-11eb-9b45-73438b0e6fc9.png)
