### PR TITLE
Bugfix/init provider curve task

### DIFF
--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -182,11 +182,6 @@ async function main() {
   ))
   await oracle.deployed()
 
-  console.log({
-    coordinator: Coordinator.address,
-    registry: Registry.address,
-    database: Database.address,
-  })
 }
 
 main()

--- a/tasks/initProvider.js
+++ b/tasks/initProvider.js
@@ -98,14 +98,14 @@ task("initiateProvider", "Initializes the first 20 accounts as a Provider")
             // Stores each provider initiated status as a boolean
             providerStatus.push(await registry.connect(signers[i]).isProviderInitiated(signers[i].address));
 
-            console.log({
-                title: ethers.utils.parseBytes32String(providerTitles[i]),
-                bytes32Title: providerTitles[i],
-                address: signers[i].address,
-                publicKey: parseInt(providerPublicKeys[i]._hex),
-                hexPublicKey: providerPublicKeys[i]._hex,
-                status: providerStatus[i]
-            });
+            // console.log({
+            //     title: ethers.utils.parseBytes32String(providerTitles[i]),
+            //     bytes32Title: providerTitles[i],
+            //     address: signers[i].address,
+            //     publicKey: parseInt(providerPublicKeys[i]._hex),
+            //     hexPublicKey: providerPublicKeys[i]._hex,
+            //     status: providerStatus[i]
+            // });
 
         }
 

--- a/tasks/initProvider.js
+++ b/tasks/initProvider.js
@@ -98,14 +98,14 @@ task("initiateProvider", "Initializes the first 20 accounts as a Provider")
             // Stores each provider initiated status as a boolean
             providerStatus.push(await registry.connect(signers[i]).isProviderInitiated(signers[i].address));
 
-            // console.log({
-            //     title: ethers.utils.parseBytes32String(providerTitles[i]),
-            //     bytes32Title: providerTitles[i],
-            //     address: signers[i].address,
-            //     publicKey: parseInt(providerPublicKeys[i]._hex),
-            //     hexPublicKey: providerPublicKeys[i]._hex,
-            //     status: providerStatus[i]
-            // });
+            console.log({
+                title: ethers.utils.parseBytes32String(providerTitles[i]),
+                //bytes32Title: providerTitles[i],
+                address: signers[i].address,
+                publicKey: parseInt(providerPublicKeys[i]._hex),
+                // hexPublicKey: providerPublicKeys[i]._hex,
+                status: providerStatus[i]
+            });
 
         }
 

--- a/tasks/initProviderCurve.js
+++ b/tasks/initProviderCurve.js
@@ -77,7 +77,7 @@ task("initiateProviderCurve", "Initializes the first 20 provider accounts with a
 
             } catch (err) {
 
-                console.log(signers[i].address + ' Provider curve is already initiated')
+                console.log(signers[i].address + ': Provider curve is already initiated')
             }
 
             curves.push(await registry.connect(signers[i]).getProviderCurve(signers[i].address, endpoint[i]))

--- a/tasks/initProviderCurve.js
+++ b/tasks/initProviderCurve.js
@@ -9,9 +9,15 @@ task("initiateProviderCurve", "Initializes the first 20 provider accounts with a
 
         // Test accounts
         const signers = await ethers.getSigners();
-        let curves = [];
+
+        // Storage for the provider curves returned from getProviderCurve()
+        let getCurves = [];
+
+        // Storage for the parsed provider ccurve
         let coefficientArr = [];
 
+        // Empty broker address
+        const broker = '0x0000000000000000000000000000000000000000';
 
         // Connection to Registry.sol
         const Registry = await ethers.getContractFactory('Registry');
@@ -41,38 +47,39 @@ task("initiateProviderCurve", "Initializes the first 20 provider accounts with a
             "Nakamoto"
         ];
 
-        endpoint = endpoint.map(name => ethers.utils.formatBytes32String(name));
-
+        // 20 test curves
         const curve = [
+            [3, 0, 0, 1, 122],
+            [3, 0, 0, 1, 10000],
+            [3, 0, 0, 1, 1222],
+            [1, 100, 1000],
             [3, 0, 2, 1, 100],
-            [3, 0, 2, 1, 100],
-            [3, 0, 2, 1, 100],
-            [3, 0, 2, 1, 100],
-            [3, 0, 2, 1, 100],
-            [3, 0, 2, 1, 100],
-            [3, 0, 2, 1, 100],
-            [3, 0, 2, 1, 100],
-            [3, 0, 2, 1, 100],
-            [3, 0, 2, 1, 100],
-            [3, 0, 2, 1, 100],
-            [3, 0, 2, 1, 100],
-            [3, 0, 2, 1, 100],
-            [3, 0, 2, 1, 100],
-            [3, 0, 2, 1, 100],
-            [3, 0, 2, 1, 100],
-            [3, 0, 2, 1, 100],
-            [3, 0, 2, 1, 100],
-            [3, 0, 2, 1, 100],
-            [3, 0, 2, 1, 100],
-
+            [2, 0, 0, 10000],
+            [1, 1000, 10000],
+            [1, 10000, 100000],
+            [2, 5000, 2000, 1000, 2, 0, 3000, 10000],
+            [2, 5000, 2000, 1000],
+            [2, 7000, 1000, 10000],
+            [2, 5000, 2000, 1000, 2, 0, 2000, 10000],
+            [3, 0, 2000, 1000, 10000],
+            [3, 0, 20000, 10000, 100000],
+            [3, 0, 2000, 10000, 100000],
+            [1, 100000, 1000000],
+            [2, 7000, 70000, 1000000],
+            [2, 70000, 7000000, 1000000],
+            [2, 0, 1, 1000000],
+            [2, 0, 1000, 100000],
         ]
 
-        const broker = '0x0000000000000000000000000000000000000000';
+        // Converts the endpoint array to an array of bytes32 strings
+        endpoint = endpoint.map(name => ethers.utils.formatBytes32String(name));
 
         for (var i = 0; i < signers.length; i++) {
 
             try {
 
+                // Connects the 20 test accounts to Registry.sol as signers
+                // Initiates the 20 test accounts with provider curves
                 await registry.connect(signers[i]).initiateProviderCurve(endpoint[i], curve[i], broker);
 
             } catch (err) {
@@ -80,9 +87,10 @@ task("initiateProviderCurve", "Initializes the first 20 provider accounts with a
                 console.log(signers[i].address + ': Provider curve is already initiated')
             }
 
-            curves.push(await registry.connect(signers[i]).getProviderCurve(signers[i].address, endpoint[i]))
+            getCurves.push(await registry.connect(signers[i]).getProviderCurve(signers[i].address, endpoint[i]))
 
-            coefficientArr.push(curves[i].map(item => parseInt(item._hex)));
+            // Converts each curve coordinate from a hexstring to a number
+            coefficientArr.push(getCurves[i].map(item => parseInt(item._hex)));
 
             console.log({
                 endpoint: ethers.utils.parseBytes32String(endpoint[i]),

--- a/tasks/initProviderCurve.js
+++ b/tasks/initProviderCurve.js
@@ -1,70 +1,83 @@
-const { task, taskArgs }  = require("hardhat/config");
+const { task, taskArgs } = require("hardhat/config");
 require("hardhat-deploy-ethers");
 require("hardhat-deploy");
 
-task("initiate-Provider-Curve", "Initializes the first 20 provider accounts with a unique bonding curve")
+task("initiateProviderCurve", "Initializes the first 20 provider accounts with a unique bonding curve")
 
     .setAction(async () => {
-        
-        // Stores the titles of all 20 providers
-        const title = ["Slothrop", "Blicero", "Borgesius", "Enzian", "Pointsman", "Tchitcherine", "Achtfaden", "Andreas", "Bianca", "Bland", "Bloat", "Bodine", "Bounce", "Bummer", "Byron the Bulb", "Chiclitz", "Christian", "Darlene", "Dodson-Truck", "Erdmann"];
-
-        // Stores the endpoints of all 20 providers
-        const endpoint = ["Ramanujan", "Lagrange", "Wiles", "Jacobi", "Turing", "Riemann", "Poincare", "Hilbert", "Fibonacci", "Bernoulli", "Pythagoras", "Gauss", "Newton", "Euler", "Archimedes", "Euclid", "Merkle", "Shamir", "Buterin", "Nakamoto"];
-
-        // Stores the curves of all 20 providers
-        // TODO: make all the curves below more realistic and unique
-        const curve = ["1x","2x", "3x", "4x", "5x", "6x", "7x", "8x", "9x", "10x", "11x", "12x", "13x", "14x", "15x", "16x", "17x", "18x", "19x", "20x"];
 
         // Test accounts
         const signers = await ethers.getSigners();
-        console.log(signers);
 
         // Connection to Registry.sol
         const Registry = await ethers.getContractFactory('Registry');
         const registry = await Registry.attach('0xa513E6E4b8f2a923D98304ec87F64353C4D5C853');
 
-        for (var i = 0; i < signers.length; i++) {
-                // Registry.sol initializes provider on an account using ETH
-                await registry.initiateProvider(signers[i].address, title[i])
-                    .then((res) => {
-                        return res;
-                    })
-                    .catch((err) => {
-                        return err;
-                    })
-                
+        // Stores the endpoints of all 20 providers
+        let endpoint = [
+            "Ramanujan",
+            "Lagrange",
+            "Wiles",
+            "Jacobi",
+            "Turing",
+            "Riemann",
+            "Poincare",
+            "Hilbert",
+            "Fibonacci",
+            "Bernoulli",
+            "Pythagoras",
+            "Gauss",
+            "Newton",
+            "Euler",
+            "Archimedes",
+            "Euclid",
+            "Merkle",
+            "Shamir",
+            "Buterin",
+            "Nakamoto"
+        ];
 
-        // Log account details
-        console.log(
-            {
-                signer: i,
-                providerAddress: signers[i].address,
-                title: title[i],
-            },
-        );
-        //}
-        }
+        endpoint = endpoint.map(name => ethers.utils.formatBytes32String(name));
+
+        const curve = [
+            [3, 0, 2, 1, 100],
+            [3, 0, 2, 1, 100],
+            [3, 0, 2, 1, 100],
+            [3, 0, 2, 1, 100],
+            [3, 0, 2, 1, 100],
+            [3, 0, 2, 1, 100],
+            [3, 0, 2, 1, 100],
+            [3, 0, 2, 1, 100],
+            [3, 0, 2, 1, 100],
+            [3, 0, 2, 1, 100],
+            [3, 0, 2, 1, 100],
+            [3, 0, 2, 1, 100],
+            [3, 0, 2, 1, 100],
+            [3, 0, 2, 1, 100],
+            [3, 0, 2, 1, 100],
+            [3, 0, 2, 1, 100],
+            [3, 0, 2, 1, 100],
+            [3, 0, 2, 1, 100],
+            [3, 0, 2, 1, 100],
+            [3, 0, 2, 1, 100],
+
+        ]
+
+        const broker = '0x0000000000000000000000000000000000000000';
 
         for (var i = 0; i < signers.length; i++) {
-            // Registry.sol initializes curve on a provider account using ETH
-            await registry.initiateProviderCurve(endpoint[i], title[i])
+
+            await registry.connect(signers[i]).initiateProviderCurve(endpoint[i], curve[i], broker);
+
+            await registry.connect(signers[i]).getProviderCurve(signers[i].address, endpoint[i])
                 .then((res) => {
-                    return res;
+                    console.log(res)
                 })
                 .catch((err) => {
-                    return err;
+                    console.log(err)
                 })
-        
-        // Log account details
-        console.log(
-            {
-                signer: i,
-                endpoint: endpoint[i],
-                curve: curve[i],
-            },
-        );
+
 
         }
-        
+
     })

--- a/tasks/initProviderCurve.js
+++ b/tasks/initProviderCurve.js
@@ -69,7 +69,7 @@ task("initiateProviderCurve", "Initializes the first 20 provider accounts with a
             [2, 70000, 7000000, 1000000],
             [2, 0, 1, 1000000],
             [2, 0, 1000, 100000],
-        ]
+        ];
 
         // Converts the endpoint array to an array of bytes32 strings
         endpoint = endpoint.map(name => ethers.utils.formatBytes32String(name));
@@ -84,10 +84,10 @@ task("initiateProviderCurve", "Initializes the first 20 provider accounts with a
 
             } catch (err) {
 
-                console.log(signers[i].address + ': Provider curve is already initiated')
+                console.log(signers[i].address + ': Provider curve is already initiated');
             }
 
-            getCurves.push(await registry.connect(signers[i]).getProviderCurve(signers[i].address, endpoint[i]))
+            getCurves.push(await registry.connect(signers[i]).getProviderCurve(signers[i].address, endpoint[i]));
 
             // Converts each curve coordinate from a hexstring to a number
             coefficientArr.push(getCurves[i].map(item => parseInt(item._hex)));
@@ -97,7 +97,7 @@ task("initiateProviderCurve", "Initializes the first 20 provider accounts with a
                 curve: coefficientArr[i],
                 address: signers[i].address
 
-            })
+            });
 
         }
 

--- a/tasks/initProviderCurve.js
+++ b/tasks/initProviderCurve.js
@@ -1,4 +1,5 @@
 const { task, taskArgs } = require("hardhat/config");
+
 require("hardhat-deploy-ethers");
 require("hardhat-deploy");
 
@@ -8,6 +9,9 @@ task("initiateProviderCurve", "Initializes the first 20 provider accounts with a
 
         // Test accounts
         const signers = await ethers.getSigners();
+        let curves = [];
+        let coefficientArr = [];
+
 
         // Connection to Registry.sol
         const Registry = await ethers.getContractFactory('Registry');
@@ -67,16 +71,25 @@ task("initiateProviderCurve", "Initializes the first 20 provider accounts with a
 
         for (var i = 0; i < signers.length; i++) {
 
-            await registry.connect(signers[i]).initiateProviderCurve(endpoint[i], curve[i], broker);
+            try {
 
-            await registry.connect(signers[i]).getProviderCurve(signers[i].address, endpoint[i])
-                .then((res) => {
-                    console.log(res)
-                })
-                .catch((err) => {
-                    console.log(err)
-                })
+                await registry.connect(signers[i]).initiateProviderCurve(endpoint[i], curve[i], broker);
 
+            } catch (err) {
+
+                console.log(signers[i].address + ' Provider curve is already initiated')
+            }
+
+            curves.push(await registry.connect(signers[i]).getProviderCurve(signers[i].address, endpoint[i]))
+
+            coefficientArr.push(curves[i].map(item => parseInt(item._hex)));
+
+            console.log({
+                endpoint: ethers.utils.parseBytes32String(endpoint[i]),
+                curve: coefficientArr[i],
+                address: signers[i].address
+
+            })
 
         }
 


### PR DESCRIPTION
## Summary
The task will initiate test curves for the 20 test accounts

## Implementation

- Connect the 20 test accounts as signers to Registry.sol
- Initiated the 20 test accounts with unique curves
- Configured a try/catch block to expect an error if an attempt to initiate the provider curves was done more than once
- Used the getProviderCurve() to return the 20 test account curves
- Logged the successful initiate provider curve data that was stored in Registry.sol

## Files
```tasks\initProvider.js ```
``` tasks\initProviderCurve.js```

## Visual Preview
Starts the Hardhat node and deploys the contracts to localhost simultaneously by running the shell script ./start.sh
![Screenshot (160)](https://user-images.githubusercontent.com/42893948/106163970-8072fa80-6157-11eb-9603-3c382c9385a0.png)

Run the command npx hardhat --network localhost initiateProvider to initiate the 20 test accounts as a provider
for the first time and log provider data
![Screenshot (161)](https://user-images.githubusercontent.com/42893948/106164233-c039e200-6157-11eb-8d53-c7499259e571.png)

Run the command npx hardhat --network localhost initiateProviderCurve to initiate unique curves for the 20 test accounts and log the provider curve data
![Screenshot (162)](https://user-images.githubusercontent.com/42893948/106164453-f8d9bb80-6157-11eb-8984-c6803695e9e1.png)

If the command npx hardhat --network localhost initiateProviderCurve runs after the first provider curve initialization it will
catch the error and log 'signerAddress: Provider curve  is already initiated` and log provider data'
![Screenshot (163)](https://user-images.githubusercontent.com/42893948/106164648-36d6df80-6158-11eb-9d62-260b37d4676f.png)





