### PR TITLE
update MPO to solidity 5.1 for merge

### DIFF
--- a/contracts/MPO/MPOStorage.sol
+++ b/contracts/MPO/MPOStorage.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "./lib/Ownable.sol";
 
@@ -42,7 +42,7 @@ contract MPOStorage is Ownable{
 		mpoToClientId[mpoId] = _clientQueryId;
 	}
  
-	function setResponders(address[] parties) external  onlyOwner{
+	function setResponders(address[] calldata parties) external  onlyOwner{
 		responders=parties;
 		if(responderLength>parties.length){
 			responderLength = parties.length;
@@ -117,7 +117,7 @@ contract MPOStorage is Ownable{
 	function getQueryStatus(uint256 queryId) external view returns(uint256){
 		return queryStatus[queryId];
 	}
-	function getThresholdResponses(uint256 queryId) external view returns(uint256[]){
+	function getThresholdResponses(uint256 queryId) external view returns(uint256[] memory ){
 		return thresholdArr[queryId];
 	}
 
@@ -128,10 +128,10 @@ contract MPOStorage is Ownable{
 	function getResponderAddress(uint index) external view returns(address){
 		return responders[index];
 	}
-	function getResponders() external view returns (address[]){
+	function getResponders() external view returns (address[] memory){
 		return responders;
 	}
-	function getResponses(uint256 queryId) external view returns(uint256[]){
+	function getResponses(uint256 queryId) external view returns(uint256[] memory){
 		return responseArr[queryId];
 	}
 	function getDelta(uint256 queryId) external view returns(uint256){
@@ -143,7 +143,7 @@ contract MPOStorage is Ownable{
 	function getQueryThreshold(uint queryId)external view returns(bool){
 		return thresholdReached[queryId];
 	}
-	function getAverage(uint256 queryId) external view returns(int[]){
+	function getAverage(uint256 queryId) external view returns(int[] memory ){
 		require(responders.length!=0, "Division error");
 		uint total = 0;
 		uint len=0;

--- a/contracts/MPO/MultiPartyOracle.sol
+++ b/contracts/MPO/MultiPartyOracle.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "./MPOStorage.sol";
 import "./lib/Destructible.sol";
@@ -55,7 +55,7 @@ contract MultiPartyOracle {
         ztoken = ZapInterface(ztokenAddress);
         stor = MPOStorage(mpoStorageAddress);
     }
-    function setup(address[] _responders) public{
+    function setup(address[] memory _responders) public{
         stor.setResponders(_responders);
         bytes32 title = "MultiPartyOracle";
         registry.initiateProvider(12345, title);
@@ -70,7 +70,7 @@ contract MultiPartyOracle {
     // @param bytes32 endpoint Determines whether to use Onchain Providers, Offchain Providers, Non-Providers
     // @param bytes32[] endpointParams Parameters passed to providers
     // @param bool onchainSubscriber Unused boolean that determines if subscriber is a smart contract
-    function receive(uint256 id, string userQuery, bytes32 endpoint, bytes32[] endpointParams, bool onchainSubscriber) external {
+    function receive(uint256 id, string calldata userQuery, bytes32 endpoint, bytes32[] calldata endpointParams, bool onchainSubscriber) external {
         emit RecievedQuery(userQuery, endpoint, endpointParams, msg.sender);
         require(msg.sender == dispatchAddress && stor.getQueryStatus(id) == 0, "Dispatch only");
         // endpoint params [from, to, threshold, precision, delta]
@@ -87,7 +87,7 @@ contract MultiPartyOracle {
                                 block.number, now, userQuery,id,stor.getResponderAddress(i)
                                 )));
                 stor.setClientQueryId(mpoid, id);
-                emit Incoming(mpoid, stor.getResponderAddress(i),this, userQuery, "Hello?", endpointParams, true);
+                emit Incoming(mpoid, stor.getResponderAddress(i),address(this), userQuery, "Hello?", endpointParams, true);
                 
             }
         }
@@ -100,7 +100,7 @@ contract MultiPartyOracle {
     // @dev 
     uint numTrue = 0;
     uint numFalse = 0;
-    function callback(uint256 mpoId, uint256[] responses, bytes32[] msgHash, uint8[] sigv, bytes32[] sigrs) external {
+    function callback(uint256 mpoId, uint256[] calldata responses, bytes32[] calldata msgHash, uint8[] calldata sigv, bytes32[] calldata sigrs) external {
         // require(msg.sender == aggregator, "Invalid aggregator");
         
         uint256 queryId = stor.getClientQueryId(mpoId);

--- a/contracts/MPO/lib/Destructible.sol
+++ b/contracts/MPO/lib/Destructible.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 import "./Ownable.sol";
 

--- a/contracts/MPO/lib/Ownable.sol
+++ b/contracts/MPO/lib/Ownable.sol
@@ -1,7 +1,7 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 contract Ownable {
-    address public owner;
+    address payable public owner;
     event OwnershipTransferred(address indexed previousOwner,address indexed newOwner);
 
     /// @dev The Ownable constructor sets the original `owner` of the contract to the sender account.
@@ -15,7 +15,7 @@ contract Ownable {
 
     /// @dev Allows the current owner to transfer control of the contract to a newOwner.
     /// @param newOwner The address to transfer ownership to.
-    function transferOwnership(address newOwner) public onlyOwner {
+    function transferOwnership(address payable newOwner) public onlyOwner {
        require(newOwner != address(0));
        emit OwnershipTransferred(owner, newOwner);
        owner = newOwner;

--- a/contracts/MPO/lib/ZapInterface.sol
+++ b/contracts/MPO/lib/ZapInterface.sol
@@ -1,13 +1,13 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.1;
 
 contract ZapInterface{
     //event
     event Transfer(address indexed from, address indexed to, uint256 value);
     //coordinator
-    function getContract(string contractName) public view returns (address); 
+    function getContract(string memory contractName) public view returns (address); 
     //registry
     function initiateProvider(uint256, bytes32) public returns (bool);
-    function initiateProviderCurve(bytes32, int256[], address) public returns (bool);
+    function initiateProviderCurve(bytes32, int256[] memory,address) public returns (bool);
     //bondage
     function bond(address, bytes32, uint256) external returns(uint256);
     function unbond(address, bytes32, uint256) external returns (uint256);
@@ -22,13 +22,13 @@ contract ZapInterface{
     function getZapBound(address, bytes32) public view returns (uint256);
     function dotLimit( address, bytes32) public view returns (uint256);
     //dispatch
-    function query(address, string, bytes32, bytes32[]) external returns (uint256); 
-    function respond1(uint256, string) external returns (bool);
-    function respond2(uint256, string, string) external returns (bool);
-    function respond3(uint256, string, string, string) external returns (bool);
-    function respond4(uint256, string, string, string, string) external returns (bool);
-    function respondBytes32Array(uint256, bytes32[]) external returns (bool);
-    function respondIntArray(uint256,int[] ) external returns (bool);
+    function query(address, string calldata, bytes32, bytes32[] calldata) external returns (uint256); 
+    function respond1(uint256, string calldata) external returns (bool);
+    function respond2(uint256, string calldata, string calldata) external returns (bool);
+    function respond3(uint256, string calldata, string calldata, string calldata) external returns (bool);
+    function respond4(uint256, string calldata, string calldata, string calldata, string calldata) external returns (bool);
+    function respondBytes32Array(uint256, bytes32[] calldata) external returns (bool);
+    function respondIntArray(uint256,int[] calldata) external returns (bool);
     // Token
     function balanceOf(address who) public view returns (uint256); 
     function transfer(address to, uint256 value) public returns (bool);


### PR DESCRIPTION
## Summary
Update Multi Party Oracle to solidity 5.1 to facilitate Testing.

## Implementation
Changing solidity type definitions to meet solidity v5 standards.

## Files 
contracts/MPO/MPOStorage.sol
contracts/MPO/MultiPartyOracle.sol
contracts/MPO/lib/Destructible.sol
contracts/MPO/lib/Ownable.sol
contracts/MPO/lib/ZapInterface.sol