### PR TITLE
Get BSC Gas Price from Api

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -25,6 +25,8 @@ import './tasks/dispatchCGPriceClient';
 import './tasks/dispatchBittrex';
 import './tasks/checkClient';
 
+import {getGasPrice} from './scripts/getGasPrice'
+
 // TODO: reenable solidity-coverage when it works
 // import "solidity-coverage";
 
@@ -36,6 +38,8 @@ const ETHERSCAN_API_KEY = process.env.ETHERSCAN_API_KEY;
 const KOVAN_PRIVATE_KEY = process.env.KOVAN_PRIVATE_KEY ||
   "0xc87509a1c067bbde78beb793e6fa76530b6382a4c0241e5e4a9ec0a0f44dc0d3";
 
+let latest_gas_usd = getGasPrice()
+
 const config = {
 
   solidity: {
@@ -44,7 +48,7 @@ const config = {
   gasReporter: {
     enabled: true,
     currency: "USD",
-    gasPrice: 39.44,
+    gasPrice: latest_gas_usd,
     coinmarketcap: process.env.COINMARKETCAP_API_KEY
   },
   networks: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "dependencies": {
         "hardhat-deploy": "^0.7.5",
         "hardhat-gas-reporter": "^1.0.4",
+        "node-cache": "^5.1.2",
         "ping": "^0.4.0",
         "pm2": "^4.5.4"
       },
@@ -3042,6 +3043,14 @@
         "string-width": "^1.0.1",
         "strip-ansi": "^3.0.1",
         "wrap-ansi": "^2.0.0"
+      }
+    },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/clone-response": {
@@ -7360,15 +7369,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ganache-core/node_modules/clone": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/ganache-core/node_modules/clone-response": {
@@ -17891,6 +17891,17 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
       "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
     },
+    "node_modules/node-cache": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
+      "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
+      "dependencies": {
+        "clone": "2.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/node-emoji": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.10.0.tgz",
@@ -25138,6 +25149,11 @@
         "wrap-ansi": "^2.0.0"
       }
     },
+    "clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
+    },
     "clone-response": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
@@ -29065,12 +29081,6 @@
               "dev": true
             }
           }
-        },
-        "clone": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-          "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
-          "dev": true
         },
         "clone-response": {
           "version": "1.0.2",
@@ -38338,6 +38348,14 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
       "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
+    },
+    "node-cache": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
+      "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
+      "requires": {
+        "clone": "2.x"
+      }
     },
     "node-emoji": {
       "version": "1.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2575,6 +2575,7 @@
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.2.tgz",
       "integrity": "sha512-AtnG3W6M8B2n4xDQ5R+70EXvOpnXsFYg/AK2yTZd+HQ/oxAdz+GI+DvjmhBw3L0ole+LJ0ngqY4JMbDzkfNzhA==",
       "dev": true,
+      "hasInstallScript": true,
       "dependencies": {
         "node-gyp-build": "^4.2.0"
       }
@@ -7041,6 +7042,7 @@
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.1.tgz",
       "integrity": "sha512-xowrxvpxojqkagPcWRQVXZl0YXhRhAtBEIq3VoER1NH5Mw1n1o0ojdspp+GS2J//2gCVyrzQDApQ4unGF+QOoA==",
       "dev": true,
+      "hasInstallScript": true,
       "dependencies": {
         "node-gyp-build": "~3.7.0"
       }
@@ -11082,6 +11084,7 @@
       "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
       "integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
       "dev": true,
+      "hasInstallScript": true,
       "dependencies": {
         "node-addon-api": "^2.0.0",
         "node-gyp-build": "^4.2.0"
@@ -12835,6 +12838,7 @@
       "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
       "integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
       "dev": true,
+      "hasInstallScript": true,
       "dependencies": {
         "elliptic": "^6.5.2",
         "node-addon-api": "^2.0.0",
@@ -14134,6 +14138,7 @@
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.2.tgz",
       "integrity": "sha512-SwV++i2gTD5qh2XqaPzBnNX88N6HdyhQrNNRykvcS0QKvItV9u3vPEJr+X5Hhfb1JC0r0e1alL0iB09rY8+nmw==",
       "dev": true,
+      "hasInstallScript": true,
       "dependencies": {
         "node-gyp-build": "~3.7.0"
       }
@@ -16666,6 +16671,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
       "integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
+      "hasInstallScript": true,
       "dependencies": {
         "node-addon-api": "^2.0.0",
         "node-gyp-build": "^4.2.0"
@@ -19645,6 +19651,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
       "integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
+      "hasInstallScript": true,
       "dependencies": {
         "elliptic": "^6.5.2",
         "node-addon-api": "^2.0.0",
@@ -21233,6 +21240,7 @@
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.3.tgz",
       "integrity": "sha512-jtJM6fpGv8C1SoH4PtG22pGto6x+Y8uPprW0tw3//gGFhDDTiuksgradgFN6yRayDP4SyZZa6ZMGHLIa17+M8A==",
       "dev": true,
+      "hasInstallScript": true,
       "dependencies": {
         "node-gyp-build": "^4.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "hardhat-deploy": "^0.7.5",
     "hardhat-gas-reporter": "^1.0.4",
+    "node-cache": "^5.1.2",
     "ping": "^0.4.0",
     "pm2": "^4.5.4"
   }

--- a/scripts/getGasPrice.ts
+++ b/scripts/getGasPrice.ts
@@ -1,67 +1,33 @@
 const fs = require("fs");
 
-function ethPrice() {
+export function ethPrice() {
     // https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd
-    const https = require('https');
-
-    let url = "https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd";
-
-    https.get(url,(res: any) => {
-        let body = "";
-
-        res.on("data", (chunk: any) => {
-            body += chunk;
-        });
-
-        res.on("end", () => {
-            try {
-                let json = JSON.parse(body);
-                return json.ethereum.usd
-            } catch (error) {
-                console.error(error.message);
-            };
-        });
-
-    }).on("error", (error: any) => {
-        console.error(error.message);
-    });
-
-    return null
+    const axios = require("axios")
+    axios.get('https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd')
+    .then((res: any)=>{
+        fs.writeFile("./output/eth_usd.txt", res.data.ethereum.usd.toString(), function(err: any){
+            console.log(err)
+        })
+    })
+    .catch((err: any)=>{
+        console.log(err)
+        return null
+    })
 
 }
 
 export function getGasPrice() {
-    const https = require('https');
+    const axios = require("axios")
 
-    let url = "https://bscgas.info/gas";
-
-    let gasPrice = null
-
-    https.get(url,(res: any) => {
-        let body = "";
-
-        res.on("data", (chunk: any) => {
-            body += chunk;
-        });
-
-        res.on("end", () => {
-            try {
-                let json = JSON.parse(body);
-                gasPrice = Number(json.fast)
-
-                let price = gasPrice * 0.000000001  // gwei to eth
-
-                price = price * Number(ethPrice())  // eth to usd
-
-                return price
-            } catch (error) {
-                console.error(error.message);
-            };
-        });
-
-    }).on("error", (error: any) => {
-        console.error(error.message);
-    });
-
-    return null
+    axios.get('https://ethgasstation.info/json/ethgasAPI.json')
+    .then((res: any)=>{
+        // console.log(typeof Number.parseInt(res.data.fastest))
+        fs.writeFile("./output/gas.txt", (res.data.fastest / 10).toString(), function(err: any){
+            console.log(err)
+        })
+    })
+    .catch((err: any)=>{
+        console.log(err)
+        return null
+    })
 }

--- a/scripts/getGasPrice.ts
+++ b/scripts/getGasPrice.ts
@@ -1,21 +1,6 @@
 const fs = require("fs");
 
-export function ethPrice() {
-    // https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd
-    const axios = require("axios")
-    axios.get('https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd')
-    .then((res: any)=>{
-        fs.writeFile("./output/eth_usd.txt", res.data.ethereum.usd.toString(), function(err: any){
-            console.log(err)
-        })
-    })
-    .catch((err: any)=>{
-        console.log(err)
-        return null
-    })
-
-}
-
+// Gets the Eth Gas Price from EthGasStation
 export function getGasPrice() {
     const axios = require("axios")
 
@@ -23,6 +8,35 @@ export function getGasPrice() {
     .then((res: any)=>{
         // console.log(typeof Number.parseInt(res.data.fastest))
         fs.writeFile("./output/gas.txt", (res.data.fastest / 10).toString(), function(err: any){
+            console.log(err)
+        })
+    })
+    .catch((err: any)=>{
+        console.log(err)
+        return null
+    })
+}
+
+export function getBSCGasPrice() {
+    const axios = require("axios")
+
+    axios.get('https://bscscan.com/chart/gasprice?output=csv')
+    .then((res: any)=>{
+        let csv = res.data
+        // split response into an array of
+        // each line in response is an element
+        csv = csv.split("\r\n")
+
+        // the latest BSC gas price is the last element of the last line
+        let latestGas = csv[csv.length - 2].split(",")
+        latestGas = latestGas[latestGas.length - 1]
+
+        if (!fs.existsSync("./output")){
+            fs.mkdirSync("./output")
+        }
+
+        // write latest gas price to file
+        fs.writeFile("./output/bscGas.txt", (latestGas), function(err: any){
             console.log(err)
         })
     })

--- a/scripts/getGasPrice.ts
+++ b/scripts/getGasPrice.ts
@@ -1,0 +1,67 @@
+const fs = require("fs");
+
+function ethPrice() {
+    // https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd
+    const https = require('https');
+
+    let url = "https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd";
+
+    https.get(url,(res: any) => {
+        let body = "";
+
+        res.on("data", (chunk: any) => {
+            body += chunk;
+        });
+
+        res.on("end", () => {
+            try {
+                let json = JSON.parse(body);
+                return json.ethereum.usd
+            } catch (error) {
+                console.error(error.message);
+            };
+        });
+
+    }).on("error", (error: any) => {
+        console.error(error.message);
+    });
+
+    return null
+
+}
+
+export function getGasPrice() {
+    const https = require('https');
+
+    let url = "https://bscgas.info/gas";
+
+    let gasPrice = null
+
+    https.get(url,(res: any) => {
+        let body = "";
+
+        res.on("data", (chunk: any) => {
+            body += chunk;
+        });
+
+        res.on("end", () => {
+            try {
+                let json = JSON.parse(body);
+                gasPrice = Number(json.fast)
+
+                let price = gasPrice * 0.000000001  // gwei to eth
+
+                price = price * Number(ethPrice())  // eth to usd
+
+                return price
+            } catch (error) {
+                console.error(error.message);
+            };
+        });
+
+    }).on("error", (error: any) => {
+        console.error(error.message);
+    });
+
+    return null
+}


### PR DESCRIPTION
## Summary
Adds a script that gets the latest gas price from https://bscscan.com/chart/gasprice for hardhat

## Implementation
- script written to get gas price .csv data from bscscan
    - .csv is broken up into lines then the gas price of the last entry is extracted
    - sets gas price into an output text file
    - gas price is read from hardhat config and set for environment
    - falls back to ETHGasPrice if it can not obtain the BSCGasPrice

## Files
``` hardhat.config.ts```
``` scripts/getGasPrice.ts```

## Future
- Find a way to ensure BSC gas price is always returned.
